### PR TITLE
Add gpt4o and gpt-4o-mini support

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -43,6 +43,8 @@ This postamble can be modified by setting the `prompt_postamble` variable in `sh
 **Supporting additional models**
 
 We natively provide support for the following models:
+- GPT-4o-mini (`gpt-4o-mini`)
+- GPT-4o (`gpt-4o-2024-05-13`)
 - GPT-4-Turbo (`gpt-4-0125-preview`)
 - GPT-4 (`gpt-4-0613`)
 - GPT-4-32K (`gpt-4-32k-0613`)

--- a/common/README.md
+++ b/common/README.md
@@ -43,7 +43,7 @@ This postamble can be modified by setting the `prompt_postamble` variable in `sh
 **Supporting additional models**
 
 We natively provide support for the following models:
-- GPT-4o-mini (`gpt-4o-mini`)
+- GPT-4o-mini (`gpt-4o-mini-2024-07-18`)
 - GPT-4o (`gpt-4o-2024-05-13`)
 - GPT-4-Turbo (`gpt-4-0125-preview`)
 - GPT-4 (`gpt-4-0613`)

--- a/common/modeling.py
+++ b/common/modeling.py
@@ -53,7 +53,10 @@ class Usage(pg.Object):
 class LMSamplingResult(lf.LMSamplingResult):
   """LMSamplingResult with usage information."""
 
-  usage: Usage | None = None
+  usage: Annotated[
+      lf.LMSamplingUsage,
+      'Usage information. Currently only OpenAI models are supported.',
+  ] = lf.UsageNotAvailable()
 
 
 @lf.use_init_args(['model'])

--- a/common/shared_config.py
+++ b/common/shared_config.py
@@ -39,7 +39,7 @@ anthropic_api_key = ''
 serper_api_key = ''
 random_seed = 1
 model_options = {
-    'gpt_4o_mini': 'OPENAI:gpt-4o-mini',
+    'gpt_4o_mini': 'OPENAI:gpt-4o-mini-2024-07-18',
     'gpt_4o': 'OPENAI:gpt-4o-2024-05-13',
     'gpt_4_turbo': 'OPENAI:gpt-4-0125-preview',
     'gpt_4': 'OPENAI:gpt-4-0613',

--- a/common/shared_config.py
+++ b/common/shared_config.py
@@ -39,6 +39,8 @@ anthropic_api_key = ''
 serper_api_key = ''
 random_seed = 1
 model_options = {
+    'gpt_4o_mini': 'OPENAI:gpt-4o-mini',
+    'gpt_4o': 'OPENAI:gpt-4o-2024-05-13',
     'gpt_4_turbo': 'OPENAI:gpt-4-0125-preview',
     'gpt_4': 'OPENAI:gpt-4-0613',
     'gpt_4_32k': 'OPENAI:gpt-4-32k-0613',
@@ -52,6 +54,8 @@ model_options = {
     'claude_instant': 'ANTHROPIC:claude-instant-1.2',
 }
 model_string = {
+    'gpt_4o_mini': 'gpt4omini',
+    'gpt_4o': 'gpt4o',
     'gpt_4_turbo': 'gpt4turbo',
     'gpt_4': 'gpt4',
     'gpt_4_32k': 'gpt432k',

--- a/data_creation/config.py
+++ b/data_creation/config.py
@@ -35,7 +35,7 @@ from common import shared_config
 #     'claude_instant',
 # ]
 ################################################################################
-generator_model = 'gpt_4o_mini'
+generator_model = 'gpt_4'
 generation_temp = 1.0
 
 ################################################################################

--- a/data_creation/config.py
+++ b/data_creation/config.py
@@ -21,6 +21,8 @@ from common import shared_config
 # generator_model: str = the model for generating data.
 # generation_temp: float = temperature to use when generating responses.
 # Currently supported models (copy-paste into `generator_model` field): [
+#     'gpt_4o_mini',
+#     'gpt_4o',
 #     'gpt_4_turbo',
 #     'gpt_4',
 #     'gpt_4_32k',
@@ -33,7 +35,7 @@ from common import shared_config
 #     'claude_instant',
 # ]
 ################################################################################
-generator_model = 'gpt_4'
+generator_model = 'gpt_4o_mini'
 generation_temp = 1.0
 
 ################################################################################

--- a/data_creation/config_test.py
+++ b/data_creation/config_test.py
@@ -26,6 +26,8 @@ from data_creation import config
 # pylint: enable=g-bad-import-order
 
 _ACCEPTED_MODELS = (
+    'gpt_4o_mini',
+    'gpt_4o',
     'gpt_4_turbo',
     'gpt_4',
     'gpt_4_32k',

--- a/eval/safe/config.py
+++ b/eval/safe/config.py
@@ -34,7 +34,7 @@ from common import shared_config
 #     'claude_instant',
 # ]
 ################################################################################
-model_short = 'gpt_35_turbo'
+model_short = 'gpt_4o_mini'
 model_temp = 0.1
 max_tokens = 512
 

--- a/eval/safe/config.py
+++ b/eval/safe/config.py
@@ -34,7 +34,7 @@ from common import shared_config
 #     'claude_instant',
 # ]
 ################################################################################
-model_short = 'gpt_4o_mini'
+model_short = 'gpt_35_turbo'
 model_temp = 0.1
 max_tokens = 512
 

--- a/eval/safe/config_test.py
+++ b/eval/safe/config_test.py
@@ -26,6 +26,8 @@ from eval.safe import config
 # pylint: enable=g-bad-import-order
 
 _SUPPORTED_MODELS = (
+    'gpt_4o_mini'
+    'gpt_4o'
     'gpt_4_turbo',
     'gpt_4',
     'gpt_4_32k',

--- a/main/README.md
+++ b/main/README.md
@@ -46,10 +46,12 @@ This can be done by adding your Anthropic API key into the `common/shared_config
 
 **Changing the language model**
 
-The default configuration is set to use `GPT-3.5-Turbo` to respond to prompts.
+The default configuration is set to use `GPT-4o-mini` to respond to prompts.
 To use any other model, simply copy-paste the desired model into the `responder_model_short` variable in `config.py`.
 If a model that you would like to test on is not listed in the currently-supported models, see the README in the `common/` folder for information on how to add support for additional models.
 Currently-supported models:
+- `gpt_4o_mini`: links to `gpt-4o-mini-2024-07-18`.
+- `gpt_4o`: links to `gpt-4o-2024-05-13`.
 - `gpt_4_turbo`: links to `gpt-4-0125-preview`.
 - `gpt_4`: links to `gpt-4-0613`.
 - `gpt_4_32k`: links to `gpt-4-32k-0613`.

--- a/main/README.md
+++ b/main/README.md
@@ -46,7 +46,7 @@ This can be done by adding your Anthropic API key into the `common/shared_config
 
 **Changing the language model**
 
-The default configuration is set to use `GPT-4o-mini` to respond to prompts.
+The default configuration is set to use `GPT-3.5-Turbo` to respond to prompts.
 To use any other model, simply copy-paste the desired model into the `responder_model_short` variable in `config.py`.
 If a model that you would like to test on is not listed in the currently-supported models, see the README in the `common/` folder for information on how to add support for additional models.
 Currently-supported models:

--- a/main/config.py
+++ b/main/config.py
@@ -40,6 +40,8 @@ save_results = True
 #                               MODEL SETTINGS
 # responder_model_short: str = model for getting structures.
 # Currently supported models (copy-paste into fields): [
+#     'gpt_4o_mini',
+#     'gpt_4o',
 #     'gpt_4_turbo',
 #     'gpt_4',
 #     'gpt_4_32k',
@@ -53,7 +55,7 @@ save_results = True
 #     'claude_instant',
 # ]
 ################################################################################
-responder_model_short = 'gpt_35_turbo'
+responder_model_short = 'gpt_4o_mini'
 
 ################################################################################
 #                               DEBUG SETTINGS

--- a/main/config.py
+++ b/main/config.py
@@ -55,7 +55,7 @@ save_results = True
 #     'claude_instant',
 # ]
 ################################################################################
-responder_model_short = 'gpt_4o_mini'
+responder_model_short = 'gpt_35_turbo'
 
 ################################################################################
 #                               DEBUG SETTINGS

--- a/main/config_test.py
+++ b/main/config_test.py
@@ -34,6 +34,8 @@ ACCEPTED_METHODS = (
     'none',
 )
 ACCEPTED_MODELS = (
+    'gpt_4o_mini',
+    'gpt_4o',
     'gpt_4_turbo',
     'gpt_4',
     'gpt_4_32k',

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ absl-py==2.1.0
 aiohttp==3.9.3
 aiosignal==1.3.1
 annotated-types==0.6.0
-anthropic==0.16.0
+anthropic==0.33.0
 anyio==4.2.0
 async-timeout==4.0.3
 attrs==23.2.0
@@ -41,7 +41,7 @@ Jinja2==3.1.3
 joblib==1.3.2
 kiwisolver==1.4.5
 langcodes==3.3.0
-langfun==0.0.2.dev20240202
+langfun==0.1.1.dev20240810
 MarkupSafe==2.1.5
 matplotlib==3.8.2
 mpmath==1.3.0
@@ -73,7 +73,7 @@ pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pydantic==2.6.0
 pydantic_core==2.16.1
-pyglove==0.4.5.dev20240202
+pyglove==0.4.5.dev20240810
 pyparsing==3.1.1
 python-dateutil==2.8.2
 pytz==2024.1


### PR DESCRIPTION
This PR adds support for the `GPT-4o` and `GPT-4o-mini` models, updates configurations, and upgrades the langfun and pyglove dependencies.