### PR TITLE
Fix hardcoded '/' path separators that break on Windows

### DIFF
--- a/common/shared_config.py
+++ b/common/shared_config.py
@@ -64,6 +64,6 @@ model_string = {
     'claude_instant': 'claudeinstant',
 }
 task_options = {}
-root_dir = '/'.join(os.path.abspath(__file__).split('/')[:-2])
+root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 path_to_data = 'datasets/'
 path_to_result = 'results/'

--- a/common/utils.py
+++ b/common/utils.py
@@ -136,7 +136,7 @@ def file_exists_wrapped(filepath: str, **kwargs) -> bool:
 
 
 def make_directory_wrapped(filepath: str, **kwargs) -> None:
-  folder_name = '/'.join(filepath.split('/')[:-1])
+  folder_name = os.path.dirname(filepath)
   os.makedirs(folder_name, exist_ok=True, **kwargs)
 
 

--- a/common/utils_test.py
+++ b/common/utils_test.py
@@ -21,6 +21,7 @@ python -m common.utils_test
 
 import copy
 import os
+import tempfile
 import types
 from unittest import mock
 
@@ -189,6 +190,12 @@ class UtilsTest(absltest.TestCase):
     }
     actual_output = utils.get_attributes(mock_module)
     self.assertEqual(actual_output, expected_output)
+
+  def test_make_directory_wrapped(self) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+      filepath = os.path.join(tmpdir, 'nested', 'subdir', 'file.json')
+      utils.make_directory_wrapped(filepath)
+      self.assertTrue(os.path.isdir(os.path.dirname(filepath)))
 
   @mock.patch('common.utils.open_file_wrapped')
   @mock.patch('json.load')


### PR DESCRIPTION
## Problem

`common/shared_config.py` and `common/utils.py` compute directory paths by splitting on the literal `'/'` character:

```python
root_dir = '/'.join(os.path.abspath(__file__).split('/')[:-2])   # shared_config.py
folder_name = '/'.join(filepath.split('/')[:-1])                  # utils.py
```

On Windows, `os.path.abspath` and `os.path.join` return backslash-separated paths, so these `split('/')` calls return a single-element list. As a result:

- `shared_config.root_dir` becomes `''`, which breaks the `longfact/` dataset paths and fails the existing `SharedConfigTest.test_settings` assertion `assertNotEmpty(root_dir)`.
- `make_directory_wrapped` ends up calling `os.makedirs('', exist_ok=True)`, which raises `FileNotFoundError: [WinError 3]` whenever results are saved (e.g. `main.pipeline`, `eval.run_eval`, `data_creation.pipeline`).

## Fix

Use `os.path.dirname`, which is separator-agnostic and is the idiomatic way to get the parent directory:

```python
root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
folder_name = os.path.dirname(filepath)
```

Behavior on POSIX (forward-slash paths) is unchanged. Also added a `test_make_directory_wrapped` regression test that exercises a native-separator path.

## Verification

- Before: `python -m common.shared_config_test` fails on Windows with `AssertionError: '' has length of 0`.
- After: `common.shared_config_test` and `common.utils_test` (37 tests) both pass.